### PR TITLE
Prevent OpenSSL errors in OS X 10.11

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,8 @@ launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
 
 echo "==========Installing Ruby prerequisites=========="
 brew install openssl libyaml libffi
+# Create symlinks for OpenSSL to prevent `error: 'openssl/ssl.h' file not found`
+brew link --force openssl
 
 echo "==========Install rbenv for Ruby version management=========="
 brew install rbenv ruby-build


### PR DESCRIPTION
The default `brew install openssl` will not create the proper symlinks for OpenSSL, and you end up getting errors like the following when installing common gems like `eventmachine`:

```
compiling binder.cpp
In file included from binder.cpp:20:
./project.h:116:10: fatal error: 'openssl/ssl.h' file not found
#include <openssl/ssl.h>
         ^
1 error generated.
make: *** [binder.o] Error 1

make failed, exit code 2
```