### PR TITLE
Update readme - High Sierra homebrew permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you get an error that Postgres is not running, try running the following comm
 
 If you get this error, take recursive ownership of it:
 
-    sudo chown -R $USER:admin /usr/local
+    sudo chown -R $USER:admin /usr/local/*
 
 ## XCode License Acceptance issues
 


### PR DESCRIPTION
`/usr/local` can no longer be `chown`'d

Source: https://github.com/Homebrew/brew/issues/3228#issuecomment-332679274